### PR TITLE
Adds rake task variant for eliminating entire applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.3]
+- modifies `queuebus:unsubscribe` to decommission only the specified application when passed exactly one argument.
+
 ## [0.13.2]
 
 ### Fixes

--- a/lib/queue_bus/task_manager.rb
+++ b/lib/queue_bus/task_manager.rb
@@ -31,6 +31,13 @@ module QueueBus
       log "  ...done"
     end
 
+    def unsubscribe_app!(app_key)
+      log "Removing all subscriptions for #{app_key}"
+      app = ::QueueBus::Application.new(app_key)
+      app.unsubscribe
+      log "  ...done"
+    end
+
     def unsubscribe!
       count = 0
       ::QueueBus.dispatchers.each do |dispatcher|

--- a/lib/queue_bus/tasks.rb
+++ b/lib/queue_bus/tasks.rb
@@ -20,8 +20,9 @@ namespace :queuebus do
 
     if app_key && queue
       manager.unsubscribe_queue!(app_key, queue)
+    elsif app_key
+      manager.unsubscribe_app!(app_key)
     else
-      manager = ::QueueBus::TaskManager.new(true)
       count = manager.unsubscribe!
       puts "No subscriptions unsubscribed" if count == 0
     end

--- a/lib/queue_bus/version.rb
+++ b/lib/queue_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QueueBus
-  VERSION = '0.13.2'
+  VERSION = '0.13.3'
 end


### PR DESCRIPTION
The unsubscribe rake task, when passed two arguments, does not appear to actually delete any subscriptions. The exact reason for this is not obvious, but this is far from the only problem with the task:
- the behavior when an app is provided but a queue name is omitted is surprising and potentially destructive
- an application that uses multiple queues would require multiple runs of the task to fully decomission

Solve both of these problems with a new code path that unsubscribes a single application in its entirety. This code path already existed, but was unreachable as a safeguard against shared applications conflicting across services.